### PR TITLE
Clarify error messages on nonexistent dependencies

### DIFF
--- a/src/main/Fiddler/Build.php
+++ b/src/main/Fiddler/Build.php
@@ -122,7 +122,7 @@ class Build
                 if($isVendor){
                     throw new \RuntimeException("Requiring non-existent composer-package '" . $dependencyName . "' in '" . $packageName . "'. Please ensure it is present in composer.json.");
                 }else{
-                    throw new \RuntimeException("Requiring non existant repo-module '" . $dependencyName . "' in '" . $packageName . "'. Please check that the subdirectory exists, or append \"vendor/\" to reference a composer-package.");
+                    throw new \RuntimeException("Requiring non-existent repo-module '" . $dependencyName . "' in '" . $packageName . "'. Please check that the subdirectory exists, or append \"vendor/\" to reference a composer-package.");
                 }
 
             }

--- a/src/main/Fiddler/Build.php
+++ b/src/main/Fiddler/Build.php
@@ -113,12 +113,18 @@ class Build
         }
 
         foreach ($dependencies as $dependencyName) {
+            $isVendor = (strpos($dependencyName, 'vendor/') === 0);
             if ($dependencyName === 'vendor/php' || strpos($dependencyName, 'vendor/ext-') === 0 || strpos($dependencyName, 'vendor/lib-') === 0) {
-                continue;
+                continue; // Meta-dependencies that composer checks
             }
 
             if (!isset($packages[$dependencyName])) {
-                throw new \RuntimeException("Requiring non existant package '" . $dependencyName . "' in '" . $packageName . "'.");
+                if($isVendor){
+                    throw new \RuntimeException("Requiring non-existent composer-package '" . $dependencyName . "' in '" . $packageName . "'. Please ensure it is present in composer.json.");
+                }else{
+                    throw new \RuntimeException("Requiring non existant repo-module '" . $dependencyName . "' in '" . $packageName . "'. Please check that the subdirectory exists, or append \"vendor/\" to reference a composer-package.");
+                }
+
             }
 
             $dependency = $packages[$dependencyName];


### PR DESCRIPTION
* Shows what style of dependency is missing (internal repo-folder vs. external composer-package)
* Suggests a resolution step
* Hints at the special `vendor/` prefixing convention for composer-packages.