### PR TITLE
Set correct noDevMode in composer

### DIFF
--- a/src/main/Fiddler/Composer/Plugin.php
+++ b/src/main/Fiddler/Composer/Plugin.php
@@ -41,6 +41,6 @@ class Plugin implements PluginInterface, EventSubscriberInterface
         $flags = $event->getFlags();
         $optimize = isset($flags['optimize']) ? $flags['optimize'] : false;
 
-        $this->build->build(getcwd(), $optimize, $event->isDevMode());
+        $this->build->build(getcwd(), $optimize, !$event->isDevMode());
     }
 }


### PR DESCRIPTION
Hi there,

This PR is just a minor patch where devMode was given to `Fiddler\Build::build` but `noDevMode` was expected.