### PR TITLE
No symlinks on windows

### DIFF
--- a/src/main/Monorepo/Build.php
+++ b/src/main/Monorepo/Build.php
@@ -97,7 +97,17 @@ class Build
                     }
 
                     $binFile = $binDir . '/' . basename($binary);
-                    symlink($rootDirectory . '/' . $binary, $binFile);
+                    
+                    /**
+                     * Symlinks on Windows are weird thus straight forward
+                     * copying files is the safer bet if on Windows
+                     **/
+                    $binSrc = $rootDirectory . '/' . $binary;
+                    if ('windows' === PHP_OS_FAMILY) {
+                        cp($binSrc, $binFile);
+                    } else {
+                        symlink($rootDirectory . '/' . $binary, $binFile);
+                    }
                 }
             }
         }

--- a/src/main/Monorepo/Build.php
+++ b/src/main/Monorepo/Build.php
@@ -104,7 +104,7 @@ class Build
                      **/
                     $binSrc = $rootDirectory . '/' . $binary;
                     if ('Windows' === substr(php_uname('s'), 0, 7)) {
-                        cp($binSrc, $binFile);
+                        copy($binSrc, $binFile);
                     } else {
                         symlink($rootDirectory . '/' . $binary, $binFile);
                     }

--- a/src/main/Monorepo/Build.php
+++ b/src/main/Monorepo/Build.php
@@ -103,7 +103,7 @@ class Build
                      * copying files is the safer bet if on Windows
                      **/
                     $binSrc = $rootDirectory . '/' . $binary;
-                    if ('windows' === PHP_OS_FAMILY) {
+                    if ('Windows' === substr(php_uname('s'), 0, 7)) {
                         cp($binSrc, $binFile);
                     } else {
                         symlink($rootDirectory . '/' . $binary, $binFile);

--- a/src/main/Monorepo/Build.php
+++ b/src/main/Monorepo/Build.php
@@ -86,7 +86,8 @@ class Build
             );
 
             $binDir = $config['path'] . '/vendor/bin';
-            // remove old symlinks
+
+            // remove old symlinks or binaries
             array_map('unlink', glob($binDir . '/*'));
 
             foreach ($localRepo->getPackages() as $package) {
@@ -97,7 +98,7 @@ class Build
                     }
 
                     $binFile = $binDir . '/' . basename($binary);
-                    
+
                     /**
                      * Symlinks on Windows are weird thus straight forward
                      * copying files is the safer bet if on Windows


### PR DESCRIPTION
Using symlinks on Windows almost always requires administrator rights or non-standard configuration. It is thus safer to just copy the files to the project vendors.

More detail on the different requirements for symlinks on Windows can be found at: https://github.com/sensiolabs/SensioDistributionBundle/blob/master/Composer/ScriptHandler.php#L146..L154