### PR TITLE
Duplicates composer behavior when conflicting binary files are found.

### DIFF
--- a/src/main/Monorepo/Build.php
+++ b/src/main/Monorepo/Build.php
@@ -86,17 +86,20 @@ class Build
             );
 
             $binDir = $config['path'] . '/vendor/bin';
+            if (! is_dir($binDir)) {
+                mkdir($binDir, 0755, true);
+            }
             // remove old symlinks
             array_map('unlink', glob($binDir . '/*'));
 
             foreach ($localRepo->getPackages() as $package) {
                 foreach ($package->getBinaries() as $binary) {
-
-                    if (! is_dir($binDir)) {
-                        mkdir($binDir, 0755, true);
+                    $binFile = $binDir . '/' . basename($binary);
+                    if (file_exists($binFile)) {
+                        $this->io->write(sprintf('Skipped installation of ' . $binFile . ' for package ' . $packageName . ': name conflicts with an existing file'));
+                        continue;
                     }
 
-                    $binFile = $binDir . '/' . basename($binary);
                     symlink($rootDirectory . '/' . $binary, $binFile);
                 }
             }


### PR DESCRIPTION
Currently when two dependencies of a monorepo package have a binary with the same name, the composer-monorepo-plugin will crash with:

```
18:30 $ composer install --verbose
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Dependency resolution completed in 0.006 seconds
Analyzed 449 packages to resolve dependencies
Analyzed 1935 rules to resolve dependencies
Nothing to install or update
Package guzzle/guzzle is abandoned, you should avoid using it. Use guzzlehttp/guzzle instead.
Package herrera-io/json is abandoned, you should avoid using it. Use kherge/json instead.
Package herrera-io/phar-update is abandoned, you should avoid using it. No replacement was suggested.
Package kherge/version is abandoned, you should avoid using it. No replacement was suggested.
Generating autoload files
Generating autoload files for monorepo sub-packages with dev-dependencies.
 [Subpackage] usere/webservices/api

                          
  [ErrorException]        
  symlink(): File exists  
                          

Exception trace:
 () at /Users/robert/fda/fda-development/FDA/vendor/beberlei/composer-monorepo-plugin/src/main/Monorepo/Build.php:100
 Composer\Util\ErrorHandler::handle() at n/a:n/a
 symlink() at /Users/robert/fda/fda-development/FDA/vendor/beberlei/composer-monorepo-plugin/src/main/Monorepo/Build.php:100
 Monorepo\Build->build() at /Users/robert/fda/fda-development/FDA/vendor/beberlei/composer-monorepo-plugin/src/main/Monorepo/Composer/Plugin.php:46
 Monorepo\Composer\Plugin->generateMonorepoAutoloads() at n/a:n/a
 call_user_func() at phar:///usr/local/Cellar/composer/1.6.3/libexec/composer.phar/src/Composer/EventDispatcher/EventDispatcher.php:171
 Composer\EventDispatcher\EventDispatcher->doDispatch() at phar:///usr/local/Cellar/composer/1.6.3/libexec/composer.phar/src/Composer/EventDispatcher/EventDispatcher.php:96
 Composer\EventDispatcher\EventDispatcher->dispatchScript() at phar:///usr/local/Cellar/composer/1.6.3/libexec/composer.phar/src/Composer/Autoload/AutoloadGenerator.php:312
 Composer\Autoload\AutoloadGenerator->dump() at phar:///usr/local/Cellar/composer/1.6.3/libexec/composer.phar/src/Composer/Installer.php:302
 Composer\Installer->run() at phar:///usr/local/Cellar/composer/1.6.3/libexec/composer.phar/src/Composer/Command/InstallCommand.php:119
 Composer\Command\InstallCommand->execute() at phar:///usr/local/Cellar/composer/1.6.3/libexec/composer.phar/vendor/symfony/console/Command/Command.php:242
 Symfony\Component\Console\Command\Command->run() at phar:///usr/local/Cellar/composer/1.6.3/libexec/composer.phar/vendor/symfony/console/Application.php:842
 Symfony\Component\Console\Application->doRunCommand() at phar:///usr/local/Cellar/composer/1.6.3/libexec/composer.phar/vendor/symfony/console/Application.php:193
 Symfony\Component\Console\Application->doRun() at phar:///usr/local/Cellar/composer/1.6.3/libexec/composer.phar/src/Composer/Console/Application.php:251
 Composer\Console\Application->doRun() at phar:///usr/local/Cellar/composer/1.6.3/libexec/composer.phar/vendor/symfony/console/Application.php:117
 Symfony\Component\Console\Application->run() at phar:///usr/local/Cellar/composer/1.6.3/libexec/composer.phar/src/Composer/Console/Application.php:100
 Composer\Console\Application->run() at phar:///usr/local/Cellar/composer/1.6.3/libexec/composer.phar/bin/composer:58
 require() at /usr/local/Cellar/composer/1.6.3/libexec/composer.phar:24
```

This PR duplicates the behavior that composer itself has to handle this type of conflict: To just print a warning and skip the binary file if a conflicting one already has been symlinked.