### PR TITLE
Ignore unreadable directories in lookup

### DIFF
--- a/src/main/Monorepo/Build.php
+++ b/src/main/Monorepo/Build.php
@@ -176,6 +176,7 @@ class Build
         $finder = new Finder();
         $finder->in($rootDirectory)
                ->exclude($vendorDir)
+               ->ignoreUnreadableDirs(true)
                ->ignoreVCS(true)
                ->name('monorepo.json');
 


### PR DESCRIPTION
The plugin did not check whether it is allowed to read in a lookup path. This lead to broken configurations in repositories containing (ignored) non-user data. Granted, this is an edge case but it should not break the plugin or composer autoload.