### PR TITLE
[GH-57] Make composer-monorepo-plugin Composer v2 compatible.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     },
     "require-dev": {
         "php": "^5.5|^7.0",
-        "composer/composer": "^1.1",
+        "composer/composer": "^2.0-alpha",
         "phake/phake": "^2.2",
         "phpunit/phpunit": "~4.8"
     },

--- a/src/main/Monorepo/Composer/AutoloadGenerator.php
+++ b/src/main/Monorepo/Composer/AutoloadGenerator.php
@@ -16,9 +16,9 @@ class AutoloadGenerator extends \Composer\Autoload\AutoloadGenerator
         return $packageMap;
     }
 
-    protected function getAutoloadRealFile($useClassMap, $useIncludePath, $targetDirLoader, $useIncludeFiles, $vendorPathCode, $appBaseDirCode, $suffix, $useGlobalIncludePath, $prependAutoloader, $staticPhpVersion = 70000)
+    protected function getAutoloadRealFile($useClassMap, $useIncludePath, $targetDirLoader, $useIncludeFiles, $vendorPathCode, $appBaseDirCode, $suffix, $useGlobalIncludePath, $prependAutoloader, $staticPhpVersion = 70000, $checkPlatform)
     {
-        $file = parent::getAutoloadRealFile($useClassMap, $useIncludePath, $targetDirLoader, false, $vendorPathCode, $appBaseDirCode, $suffix, $useGlobalIncludePath, $prependAutoloader, $staticPhpVersion);
+        $file = parent::getAutoloadRealFile($useClassMap, $useIncludePath, $targetDirLoader, false, $vendorPathCode, $appBaseDirCode, $suffix, $useGlobalIncludePath, $prependAutoloader, $staticPhpVersion, $checkPlatform);
 
         if (! $useIncludeFiles) {
             return $file;

--- a/src/main/Monorepo/Composer/MonorepoInstalledRepository.php
+++ b/src/main/Monorepo/Composer/MonorepoInstalledRepository.php
@@ -4,6 +4,7 @@ namespace Monorepo\Composer;
 
 use Composer\Repository\InstalledRepositoryInterface;
 use Composer\Package\PackageInterface;
+use Composer\Installer\InstallationManager;
 
 class MonorepoInstalledRepository implements InstalledRepositoryInterface
 {
@@ -53,12 +54,31 @@ class MonorepoInstalledRepository implements InstalledRepositoryInterface
         return array();
     }
 
+    public function getProviders($packageName)
+    {
+        return [];
+    }
+
+    public function isFresh()
+    {
+        return true;
+    }
+
+    public function getRepoName()
+    {
+    }
+
     /**
      * Returns list of registered packages.
      *
      * @return array
      */
     public function getPackages()
+    {
+        return $this->packages;
+    }
+
+    public function loadPackages(array $packageNameMap, array $acceptableStabilities, array $stabilityFlags)
     {
         return $this->packages;
     }
@@ -70,7 +90,7 @@ class MonorepoInstalledRepository implements InstalledRepositoryInterface
      * @param  int     $mode  a set of SEARCH_* constants to search on, implementations should do a best effort only
      * @return array[] an array of array('name' => '...', 'description' => '...')
      */
-    public function search($query, $mode = 0)
+    public function search($query, $mode = 0, $type = null)
     {
         return array();
     }
@@ -83,7 +103,7 @@ class MonorepoInstalledRepository implements InstalledRepositoryInterface
     /**
      * Writes repository (f.e. to the disc).
      */
-    public function write()
+    public function write($devMode, InstallationManager $installationManager)
     {
     }
 

--- a/src/main/Monorepo/Composer/MonorepoInstaller.php
+++ b/src/main/Monorepo/Composer/MonorepoInstaller.php
@@ -8,69 +8,40 @@ use Composer\Repository\InstalledRepositoryInterface;
 
 class MonorepoInstaller implements InstallerInterface
 {
-    /**
-     * Decides if the installer supports the given type
-     *
-     * @param  string $packageType
-     * @return bool
-     */
     public function supports($packageType)
     {
         return $packageType === 'monorepo';
     }
 
-    /**
-     * Checks that provided package is installed.
-     *
-     * @param InstalledRepositoryInterface $repo    repository in which to check
-     * @param PackageInterface             $package package instance
-     *
-     * @return bool
-     */
     public function isInstalled(InstalledRepositoryInterface $repo, PackageInterface $package)
     {
         return true;
     }
 
-    /**
-     * Installs specific package.
-     *
-     * @param InstalledRepositoryInterface $repo    repository in which to check
-     * @param PackageInterface             $package package instance
-     */
+    public function download(PackageInterface $package, PackageInterface $prevPackage = null)
+    {
+    }
+
+    public function prepare($type, PackageInterface $package, PackageInterface $prevPackage = null)
+    {
+    }
+
     public function install(InstalledRepositoryInterface $repo, PackageInterface $package)
     {
     }
 
-    /**
-     * Updates specific package.
-     *
-     * @param InstalledRepositoryInterface $repo    repository in which to check
-     * @param PackageInterface             $initial already installed package version
-     * @param PackageInterface             $target  updated version
-     *
-     * @throws InvalidArgumentException if $initial package is not installed
-     */
     public function update(InstalledRepositoryInterface $repo, PackageInterface $initial, PackageInterface $target)
     {
     }
 
-    /**
-     * Uninstalls specific package.
-     *
-     * @param InstalledRepositoryInterface $repo    repository in which to check
-     * @param PackageInterface             $package package instance
-     */
     public function uninstall(InstalledRepositoryInterface $repo, PackageInterface $package)
     {
     }
 
-    /**
-     * Returns the installation path of a package
-     *
-     * @param  PackageInterface $package
-     * @return string           path
-     */
+    public function cleanup($type, PackageInterface $package, PackageInterface $prevPackage = null)
+    {
+    }
+
     public function getInstallPath(PackageInterface $package)
     {
         return $package->getPrettyName(); // Monorepo package names are directory paths.

--- a/src/main/Monorepo/Composer/Plugin.php
+++ b/src/main/Monorepo/Composer/Plugin.php
@@ -50,4 +50,12 @@ class Plugin implements PluginInterface, EventSubscriberInterface, Capable
     {
         return [CommandProvider::class => MonorepoCommands::class];
     }
+
+    public function deactivate(Composer $composer, IOInterface $io)
+    {
+    }
+
+    public function uninstall(Composer $composer, IOInterface $io)
+    {
+    }
 }


### PR DESCRIPTION
The Composer APIs used by Monorepo Plugin are quite extensive and changes are necessary for Composer v2

Fixes #57 