### PR TITLE
Composer classmap-authoritative

### DIFF
--- a/src/main/Monorepo/Build.php
+++ b/src/main/Monorepo/Build.php
@@ -46,7 +46,7 @@ class Build
         $this->factory = new Factory();
     }
 
-    public function build($rootDirectory, $optimize = false, $noDevMode = false)
+    public function build($rootDirectory, $optimize = false, $noDevMode = false, $classmapAuthoritative = false)
     {
         $this->io->write(sprintf('<info>Generating autoload files for monorepo sub-packages %s dev-dependencies.</info>', $noDevMode ? 'without' : 'with'));
         $start = microtime(true);
@@ -60,6 +60,7 @@ class Build
         $evm = new EventDispatcher($composer, $this->io);
         $generator = new AutoloadGenerator($evm, $this->io);
         $generator->setDevMode(!$noDevMode);
+        $generator->setClassMapAuthoritative($classmapAuthoritative);
         $installationManager = $composer->getInstallationManager();
         $installationManager->addInstaller(new MonorepoInstaller());
 

--- a/src/main/Monorepo/Command/BuildCommand.php
+++ b/src/main/Monorepo/Command/BuildCommand.php
@@ -20,6 +20,7 @@ class BuildCommand extends BaseCommand
             ->setDefinition(array(
                 new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables installation of require-dev packages.'),
                 new InputOption('optimize-autoloader', 'o', InputOption::VALUE_NONE, 'Optimize autoloader during autoloader dump'),
+                new InputOption('classmap-authoritative', 'a', InputOption::VALUE_NONE, 'Autoload classes from the classmap only. Implicitly enables `--optimize`.'),
             ))
         ;
     }
@@ -28,8 +29,9 @@ class BuildCommand extends BaseCommand
     {
         $noDevMode = (bool)$input->getOption('no-dev');
         $optimize = (bool)$input->getOption('optimize-autoloader');
+        $classmapAuthoritative = (bool)$input->getOption('classmap-authoritative');
 
         $build = new Build(new ConsoleIO($input, $output, $this->getHelperSet()));
-        $build->build(getcwd(), $optimize, $noDevMode);
+        $build->build(getcwd(), $optimize, $noDevMode, $classmapAuthoritative);
     }
 }

--- a/src/main/Monorepo/Command/BuildCommand.php
+++ b/src/main/Monorepo/Command/BuildCommand.php
@@ -20,7 +20,7 @@ class BuildCommand extends BaseCommand
             ->setDefinition(array(
                 new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Disables installation of require-dev packages.'),
                 new InputOption('optimize-autoloader', 'o', InputOption::VALUE_NONE, 'Optimize autoloader during autoloader dump'),
-                new InputOption('classmap-authoritative', 'a', InputOption::VALUE_NONE, 'Autoload classes from the classmap only. Implicitly enables `--optimize`.'),
+                new InputOption('classmap-authoritative', 'a', InputOption::VALUE_NONE, 'Autoload classes from the classmap only. Implicitly enables `--optimize-autoloader`.'),
             ))
         ;
     }

--- a/src/main/Monorepo/Composer/Plugin.php
+++ b/src/main/Monorepo/Composer/Plugin.php
@@ -42,8 +42,9 @@ class Plugin implements PluginInterface, EventSubscriberInterface, Capable
     {
         $flags = $event->getFlags();
         $optimize = isset($flags['optimize']) ? $flags['optimize'] : false;
+        $classmapAuthoritative = isset($flags['classmap-authoritative']) ? $flags['classmap-authoritative'] : false;
 
-        $this->build->build(getcwd(), $optimize, !$event->isDevMode());
+        $this->build->build(getcwd(), $optimize, !$event->isDevMode(), $classmapAuthoritative);
     }
 
     public function getCapabilities()


### PR DESCRIPTION
Thanks for a great project.

Allow adding the [`--classmap-authoritative` ](https://getcomposer.org/doc/06-config.md#classmap-authoritative) flag. We currently only use this flag, as opposed to `--optimize`.

I'm happy to accommodate any comments.