### PR TITLE
Bugfix: Pass RootPackage to AutoloadGenerator::dump

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": "^5.5|^7.0|^8.0",
         "composer/composer": "^2.0.7",
         "phake/phake": "^2.2|^3.0",
-        "phpunit/phpunit": "^6|^7|^8|^9"
+        "phpunit/phpunit": "^5|^6|^7|^8|^9"
     },
     "autoload": {
         "psr-0": {"Monorepo\\": "src/main"}

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     },
     "require-dev": {
         "php": "^5.5|^7.0|^8.0",
-        "composer/composer": "^2.0",
+        "composer/composer": "^2.0.7",
         "phake/phake": "^2.2|^3.0",
         "phpunit/phpunit": "^6|^7|^8|^9"
     },

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": "^5.5|^7.0|^8.0",
         "composer/composer": "^2.0",
         "phake/phake": "^2.2|^3.0",
-        "phpunit/phpunit": "*"
+        "phpunit/phpunit": "^6|^7|^8|^9"
     },
     "autoload": {
         "psr-0": {"Monorepo\\": "src/main"}

--- a/src/main/Monorepo/Build.php
+++ b/src/main/Monorepo/Build.php
@@ -25,6 +25,7 @@ use Composer\Config;
 use Composer\Composer;
 use Composer\Factory;
 use Composer\Package\Package;
+use Composer\Package\RootPackage;
 use Composer\Util\Filesystem;
 
 /**
@@ -72,7 +73,7 @@ class Build
 
             $this->io->write(sprintf(' [Subpackage] <comment>%s</comment>', $packageName));
 
-            $mainPackage = new Package($packageName, "@stable", "@stable");
+            $mainPackage = new RootPackage($packageName, "@stable", "@stable");
             $mainPackage->setType('monorepo');
             $mainPackage->setAutoload($config['autoload']);
             $mainPackage->setDevAutoload($config['autoload-dev']);

--- a/src/main/Monorepo/Composer/AutoloadGenerator.php
+++ b/src/main/Monorepo/Composer/AutoloadGenerator.php
@@ -4,6 +4,7 @@ namespace Monorepo\Composer;
 
 use Composer\Installer\InstallationManager;
 use Composer\Package\PackageInterface;
+use Composer\Package\RootPackageInterface;
 
 class AutoloadGenerator extends \Composer\Autoload\AutoloadGenerator
 {
@@ -39,7 +40,7 @@ function composerRequireOnce$suffix(\$file)
 INCLUDE_FILES;
     }
 
-    protected function filterPackageMap(array $packageMap, PackageInterface $mainPackage)
+    protected function filterPackageMap(array $packageMap, RootPackageInterface $mainPackage)
     {
         return $packageMap;
     }


### PR DESCRIPTION
Small change in Composer 2.0.7 requires adjustment in autoloading related code: https://github.com/composer/composer/commit/b574f10d9d68acfeb8e36cad0b0b25a090140a3b