### PR TITLE
Use the correct file package key so composer requires cache works

### DIFF
--- a/src/main/Monorepo/Build.php
+++ b/src/main/Monorepo/Build.php
@@ -149,7 +149,14 @@ class Build
             }
 
             $dependency = $packages[$dependencyName];
+
             $package = new Package($dependency['path'], "@stable", "@stable");
+            $package->setExtra([
+                'monorepo' => [
+                    'original_name' => ltrim(str_replace($vendorDir, '', $dependencyName), '/'),
+                ],
+            ]);
+
             $package->setType('monorepo');
 
             if (isset($dependency['autoload']) && is_array($dependency['autoload'])) {

--- a/src/main/Monorepo/Composer/AutoloadGenerator.php
+++ b/src/main/Monorepo/Composer/AutoloadGenerator.php
@@ -17,27 +17,15 @@ class AutoloadGenerator extends \Composer\Autoload\AutoloadGenerator
         return $packageMap;
     }
 
-    protected function getAutoloadRealFile($useClassMap, $useIncludePath, $targetDirLoader, $useIncludeFiles, $vendorPathCode, $appBaseDirCode, $suffix, $useGlobalIncludePath, $prependAutoloader, $staticPhpVersion = 70000, $checkPlatform)
+    protected function getFileIdentifier(PackageInterface $package, $path)
     {
-        $file = parent::getAutoloadRealFile($useClassMap, $useIncludePath, $targetDirLoader, false, $vendorPathCode, $appBaseDirCode, $suffix, $useGlobalIncludePath, $prependAutoloader, $staticPhpVersion, $checkPlatform);
+        $extra = $package->getExtra();
 
-        if (! $useIncludeFiles) {
-            return $file;
-        }
-
-        return $file .= <<<INCLUDE_FILES
-
-\$includeFiles = require __DIR__ . '/autoload_files.php';
-foreach (\$includeFiles as \$file) {
-    composerRequireOnce$suffix(\$file);
-}
-
-function composerRequireOnce$suffix(\$file)
-{
-    require_once \$file;
-}
-
-INCLUDE_FILES;
+        return md5(
+            $extra['monorepo']['original_name'] .
+            ':' .
+            $path
+        );
     }
 
     protected function filterPackageMap(array $packageMap, RootPackageInterface $mainPackage)

--- a/tests/Monorepo/BuildTest.php
+++ b/tests/Monorepo/BuildTest.php
@@ -71,11 +71,11 @@ class BuildTest extends TestCase
         $build = new Build();
         $build->build(__DIR__ . '/../_fixtures/example-advanced');
 
-        $barAutoloadReal = file_get_contents(__DIR__ . '/../_fixtures/example-advanced/bar/vendor/composer/autoload_real.php');
+        $barAutoloadReal = file_get_contents(__DIR__ . '/../_fixtures/example-advanced/bar/vendor/composer/autoload_files.php');
         $barIncludeFiles = include(__DIR__ . '/../_fixtures/example-advanced/bar/vendor/composer/autoload_files.php');
 
         $this->assertEquals(array(realpath(__DIR__ . '/../../') . '/vendor/foo/baz/bin/baz'), array_values($barIncludeFiles));
-        $this->assertTrue(strpos($barAutoloadReal, 'composerRequireOnce') !== false);
+        $this->assertTrue(strpos($barAutoloadReal, md5('foo/baz:bin/baz')) !== false);
     }
 
     public function testBuildWithVendorDirExampleProject()
@@ -83,11 +83,11 @@ class BuildTest extends TestCase
         $build = new Build();
         $build->build(__DIR__ . '/../_fixtures/example-vendordir');
 
-        $barAutoloadReal = file_get_contents(__DIR__ . '/../_fixtures/example-vendordir/bar/vendor/composer/autoload_real.php');
+        $barAutoloadReal = file_get_contents(__DIR__ . '/../_fixtures/example-vendordir/bar/vendor/composer/autoload_files.php');
         $barIncludeFiles = include(__DIR__ . '/../_fixtures/example-vendordir/bar/vendor/composer/autoload_files.php');
 
         $this->assertEquals(array(realpath(__DIR__ . '/../../') . '/different/folder/foo/baz/bin/baz'), array_values($barIncludeFiles));
-        $this->assertTrue(strpos($barAutoloadReal, 'composerRequireOnce') !== false);
+        $this->assertTrue(strpos($barAutoloadReal, md5('foo/baz:bin/baz')) !== false);
     }
 
     public function testBuildWithRelativeBinExampleProject()


### PR DESCRIPTION
Autoloading files is broken because composer `requires` the same file in the sub-package and root autoloaders. It does this because the `fileIdentifier` key is different due to the vendor path being included in the package name.

This PR normalises the package name so a consistent key can be generated, and the composer cache used when autoloading files.

Fixes https://github.com/beberlei/composer-monorepo-plugin/issues/38