### PR TITLE
[GH-70] installed.php also needs to be copied for runtime api

### DIFF
--- a/src/main/Monorepo/Build.php
+++ b/src/main/Monorepo/Build.php
@@ -123,6 +123,13 @@ class Build
                     $rootDirectory . '/' . $config['path'] . '/vendor/composer/InstalledVersions.php'
                 );
             }
+
+            if (file_exists($rootDirectory . '/vendor/composer/installed.php')) {
+                $fsUtil->copy(
+                    $rootDirectory . '/vendor/composer/installed.php',
+                    $rootDirectory . '/' . $config['path'] . '/vendor/composer/installed.php'
+                );
+            }
         }
 
         $duration = microtime(true) - $start;

--- a/src/main/Monorepo/Composer/AutoloadGenerator.php
+++ b/src/main/Monorepo/Composer/AutoloadGenerator.php
@@ -22,7 +22,7 @@ class AutoloadGenerator extends \Composer\Autoload\AutoloadGenerator
         $extra = $package->getExtra();
 
         return md5(
-            ($extra['monorepo']['original_name'] ?? $package->getName()).
+            (isset($extra['monorepo']['original_name']) ? $extra['monorepo']['original_name'] : $package->getName()) .
             ':' .
             $path
         );

--- a/tests/Monorepo/BuildTest.php
+++ b/tests/Monorepo/BuildTest.php
@@ -152,6 +152,7 @@ class BuildTest extends TestCase
         $build->build(__DIR__ . '/../_fixtures/example-composer-runtime-api');
 
         $this->assertFileExists(__DIR__ . '/../_fixtures/example-composer-runtime-api/foo/vendor/composer/InstalledVersions.php');
+        $this->assertFileExists(__DIR__ . '/../_fixtures/example-composer-runtime-api/foo/vendor/composer/installed.php');
     }
 
     public function __call($method, $args)

--- a/tests/_fixtures/example-composer-runtime-api/vendor/composer/InstalledVersions.php
+++ b/tests/_fixtures/example-composer-runtime-api/vendor/composer/InstalledVersions.php
@@ -30,7 +30,7 @@ private static $installed = array (
     'aliases' => 
     array (
     ),
-    'reference' => '381b163323485bfa3d00636814ca5f33f7055bcc',
+    'reference' => 'f20eec6a0204460b3080db156d3631a7ee36d4b7',
     'name' => '__root__',
   ),
   'versions' => 
@@ -42,7 +42,7 @@ private static $installed = array (
       'aliases' => 
       array (
       ),
-      'reference' => '381b163323485bfa3d00636814ca5f33f7055bcc',
+      'reference' => 'f20eec6a0204460b3080db156d3631a7ee36d4b7',
     ),
   ),
 );

--- a/tests/_fixtures/example-composer-runtime-api/vendor/composer/installed.php
+++ b/tests/_fixtures/example-composer-runtime-api/vendor/composer/installed.php
@@ -1,0 +1,24 @@
+<?php return array (
+  'root' => 
+  array (
+    'pretty_version' => 'dev-master',
+    'version' => 'dev-master',
+    'aliases' => 
+    array (
+    ),
+    'reference' => 'f20eec6a0204460b3080db156d3631a7ee36d4b7',
+    'name' => '__root__',
+  ),
+  'versions' => 
+  array (
+    '__root__' => 
+    array (
+      'pretty_version' => 'dev-master',
+      'version' => 'dev-master',
+      'aliases' => 
+      array (
+      ),
+      'reference' => 'f20eec6a0204460b3080db156d3631a7ee36d4b7',
+    ),
+  ),
+);


### PR DESCRIPTION
Previous PR #71 did not also copy the `installed.php` around, which in my tests was not a problem, however it seems the `InstalledVersions` class can vary on different Composer versions, so we need to copy both to be sure.