### PR TITLE
Implement new get dev mode in Composer interface

### DIFF
--- a/src/main/Monorepo/Build.php
+++ b/src/main/Monorepo/Build.php
@@ -80,7 +80,7 @@ class Build
             $mainPackage->setDevAutoload($config['autoload-dev']);
             $mainPackage->setIncludePaths($config['include-path']);
 
-            $localRepo = new MonorepoInstalledRepository();
+            $localRepo = new MonorepoInstalledRepository($noDevMode);
             $this->resolvePackageDependencies($localRepo, $packages, $packageName, $vendorDir, $noDevMode);
 
             $composerConfig = new Config(true, $rootDirectory);

--- a/src/main/Monorepo/Composer/MonorepoInstalledRepository.php
+++ b/src/main/Monorepo/Composer/MonorepoInstalledRepository.php
@@ -174,6 +174,6 @@ class MonorepoInstalledRepository implements InstalledRepositoryInterface
      */
     public function getDevMode()
     {
-        return !$this->noDevMode;
+        return $this->noDevMode === null ? $this->noDevMode : !$this->noDevMode;
     }
 }

--- a/src/main/Monorepo/Composer/MonorepoInstalledRepository.php
+++ b/src/main/Monorepo/Composer/MonorepoInstalledRepository.php
@@ -158,4 +158,12 @@ class MonorepoInstalledRepository implements InstalledRepositoryInterface
     public function setDevPackageNames(array $devPackageNames)
     {
     }
+
+    /**
+     * @return bool|null
+     */
+    public function getDevMode()
+    {
+        return null;
+    }
 }

--- a/src/main/Monorepo/Composer/MonorepoInstalledRepository.php
+++ b/src/main/Monorepo/Composer/MonorepoInstalledRepository.php
@@ -14,6 +14,16 @@ class MonorepoInstalledRepository implements InstalledRepositoryInterface
     private $packages = array();
 
     /**
+     * @var bool|null
+     */
+    private $noDevMode;
+
+    public function __construct($noDevMode = null)
+    {
+        $this->noDevMode = $noDevMode;
+    }
+
+    /**
      * Checks if specified package registered (installed).
      *
      * @param PackageInterface $package package instance
@@ -164,6 +174,6 @@ class MonorepoInstalledRepository implements InstalledRepositoryInterface
      */
     public function getDevMode()
     {
-        return null;
+        return !$this->noDevMode;
     }
 }


### PR DESCRIPTION
With latest version of Composer we get this issue: 

![image](https://user-images.githubusercontent.com/1544220/152845498-e7197270-76ba-45ff-be92-03cf71c515b0.png)

Implement new function [`getDevMode()`](https://github.com/composer/composer/blob/main/src/Composer/Repository/InstalledRepositoryInterface.php#L27). Should return `false` if `--no-dev` flag was present, else `true` or `null` if the flag is not known. 🙂 