### PR TITLE
Return exit code 0 from build

### DIFF
--- a/src/main/Monorepo/Command/BuildCommand.php
+++ b/src/main/Monorepo/Command/BuildCommand.php
@@ -33,5 +33,7 @@ class BuildCommand extends BaseCommand
 
         $build = new Build(new ConsoleIO($input, $output, $this->getHelperSet()));
         $build->build(getcwd(), $optimize, $noDevMode, $classmapAuthoritative);
+
+        return 0;
     }
 }


### PR DESCRIPTION
Getting an error that the build command returns `null` when in fact an exit code is expected:

![image](https://user-images.githubusercontent.com/1544220/152970332-f3984731-b898-4534-a54a-c759f76c26f8.png)

According to the [`Command`](https://github.com/symfony/console/blob/5.4/Command/Command.php#L200) contract in `symfony/console` then the function should return an exit code.

I did not want to change [`GitChangedCommand`](https://github.com/beberlei/composer-monorepo-plugin/blob/master/src/main/Monorepo/Command/GitChangedCommand.php#L71) as it already has some kind of exit code functionality. Although, exiting the PHP script, as opposed to returning an exit code, is kind of a hack as it does break the contract.