### PR TITLE
Add forward compat for composer 2.3

### DIFF
--- a/src/main/Monorepo/Composer/AutoloadGenerator.php
+++ b/src/main/Monorepo/Composer/AutoloadGenerator.php
@@ -8,7 +8,7 @@ use Composer\Package\RootPackageInterface;
 
 class AutoloadGenerator extends \Composer\Autoload\AutoloadGenerator
 {
-    public function buildPackageMap(InstallationManager $installationManager, PackageInterface $mainPackage, array $packages)
+    public function buildPackageMap(InstallationManager $installationManager, PackageInterface $mainPackage, array $packages): array
     {
         $packageMap = parent::buildPackageMap($installationManager, $mainPackage, $packages);
 
@@ -17,7 +17,7 @@ class AutoloadGenerator extends \Composer\Autoload\AutoloadGenerator
         return $packageMap;
     }
 
-    protected function getFileIdentifier(PackageInterface $package, $path)
+    protected function getFileIdentifier(PackageInterface $package, $path): string
     {
         $extra = $package->getExtra();
 
@@ -28,12 +28,12 @@ class AutoloadGenerator extends \Composer\Autoload\AutoloadGenerator
         );
     }
 
-    protected function filterPackageMap(array $packageMap, RootPackageInterface $mainPackage)
+    protected function filterPackageMap(array $packageMap, RootPackageInterface $mainPackage): array
     {
         return $packageMap;
     }
 
-    protected function getAutoloadFile($vendorPathToTargetDirCode, $suffix)
+    protected function getAutoloadFile($vendorPathToTargetDirCode, $suffix): string
     {
         $code = parent::getAutoloadFile($vendorPathToTargetDirCode, $suffix);
 

--- a/src/main/Monorepo/Composer/EventDispatcher.php
+++ b/src/main/Monorepo/Composer/EventDispatcher.php
@@ -6,11 +6,13 @@ use Composer\EventDispatcher\Event;
 
 class EventDispatcher extends \Composer\EventDispatcher\EventDispatcher
 {
-    public function dispatch($eventName, Event $event = null)
+    public function dispatch($eventName, Event $event = null): int
     {
+        return 0;
     }
 
-    public function dispatchScript($eventName, $devMode = false, $additionalArgs = array(), $flags = array())
+    public function dispatchScript($eventName, $devMode = false, $additionalArgs = array(), $flags = array()): int
     {
+        return 0;
     }
 }


### PR DESCRIPTION
We're adding return types in Composer and would rather avoid breaking dependents.