### PR TITLE
Make Vendor Directory Path Dynamic

### DIFF
--- a/src/main/Monorepo/Build.php
+++ b/src/main/Monorepo/Build.php
@@ -117,16 +117,16 @@ class Build
             }
 
             // composer-runtime-api generates InstalledVersions.php which needs to be copied to subprojects
-            if (file_exists($rootDirectory . '/vendor/composer/InstalledVersions.php')) {
+            if (file_exists($rootDirectory . '/' . $vendorDir . '/composer/InstalledVersions.php')) {
                 $fsUtil->copy(
-                    $rootDirectory . '/vendor/composer/InstalledVersions.php',
+                    $rootDirectory . '/' . $vendorDir . '/composer/InstalledVersions.php',
                     $rootDirectory . '/' . $config['path'] . '/vendor/composer/InstalledVersions.php'
                 );
             }
 
-            if (file_exists($rootDirectory . '/vendor/composer/installed.php')) {
+            if (file_exists($rootDirectory . '/' . $vendorDir . '/composer/installed.php')) {
                 $fsUtil->copy(
-                    $rootDirectory . '/vendor/composer/installed.php',
+                    $rootDirectory . '/' . $vendorDir . '/composer/installed.php',
                     $rootDirectory . '/' . $config['path'] . '/vendor/composer/installed.php'
                 );
             }


### PR DESCRIPTION
This pull request addresses an issue where the vendor directory path is currently hardcoded in the package. As per Composer's flexibility, the [vendor-dir can be configured in the root composer.json file](https://getcomposer.org/doc/06-config.md#vendor-dir). This change allows the package to respect this configuration by dynamically setting the vendor folder path, enhancing its compatibility and configurability.

